### PR TITLE
Use flags instead of deprecated regex syntax

### DIFF
--- a/reviewcheck/merge_request.py
+++ b/reviewcheck/merge_request.py
@@ -84,7 +84,7 @@ class MergeRequest:
         if self.description is None:
             return None
         # Parse the VIRA ticket number
-        jira_regex = re.compile(r".*(?i)JIRA: (.*)(\\n)*")
+        jira_regex = re.compile(r".*JIRA: (.*)(\\n)*", flags=re.IGNORECASE)
         jira_match = jira_regex.match(self.description.split("\n")[-1])
         jira = None
         if jira_match:

--- a/tests/test_merge_requests.py
+++ b/tests/test_merge_requests.py
@@ -1,0 +1,118 @@
+"""Tests for the merge_requests.py file."""
+from typing import Any, Dict, List
+
+from reviewcheck.merge_request import MergeRequest
+
+sample_mr: Dict[str, Any] = {
+    "approvals_before_merge": None,
+    "assignee": None,
+    "assignees": [],
+    "author": {
+        "avatar_url": "https://example.com/avatar.jpg",
+        "id": 5909,
+        "name": "John Doe",
+        "state": "active",
+        "username": "johndoe",
+        "web_url": "https://gitlab.com/johndoe",
+    },
+    "blocking_discussions_resolved": False,
+    "closed_at": None,
+    "closed_by": None,
+    "created_at": "2022-01-01T00:00:00.000+02:00",
+    "description": (
+        "Change functions that do not have to create an object of the "
+        "class\n"
+        "to static methods.\n"
+        "\n"
+        "JIRA: "
+        "[ARTXXX-1000](https://jira.example.com/browse/ARTXXX-1000)"
+    ),
+    "detailed_merge_status": "discussions_not_resolved",
+    "discussion_locked": None,
+    "downvotes": 0,
+    "draft": False,
+    "force_remove_source_branch": True,
+    "has_conflicts": False,
+    "id": 40000,
+    "iid": 300,
+    "labels": [],
+    "merge_commit_sha": None,
+    "merge_status": "cannot_be_merged_recheck",
+    "merge_user": None,
+    "merge_when_pipeline_succeeds": False,
+    "merged_at": None,
+    "merged_by": None,
+    "milestone": None,
+    "prepared_at": "2022-01-01T00:00:00.000+02:00",
+    "project_id": 500,
+    "reference": "!300",
+    "references": {"full": "repo!300", "relative": "!300", "short": "!300"},
+    "reviewers": [],
+    "sha": "1111111111111111aaaaaaaaaaaaaaaaaaaaaaaa",
+    "should_remove_source_branch": None,
+    "source_branch": "the-source-branch",
+    "source_project_id": 500,
+    "squash": False,
+    "squash_commit_sha": None,
+    "squash_on_merge": False,
+    "state": "opened",
+    "target_branch": "dev",
+    "target_project_id": 500,
+    "task_completion_status": {"completed_count": 0, "count": 0},
+    "time_stats": {
+        "human_time_estimate": None,
+        "human_total_time_spent": None,
+        "time_estimate": 0,
+        "total_time_spent": 0,
+    },
+    "title": "Change methods to static",
+    "updated_at": "2022-01-01T00:00:00.000+02:00",
+    "upvotes": 2,
+    "user_notes_count": 32,
+    "web_url": "https://gitlab.com/repo/-/merge_requests/300",
+    "work_in_progress": False,
+}
+
+
+sample_mr_response: List[Dict[str, Any]] = [
+    {
+        "id": "abcdef1234567890",
+        "individual_note": True,
+        "notes": [
+            {
+                "attachment": None,
+                "author": {
+                    "avatar_url": (
+                        "https://gitlab.com/uploads/-/system/user/avatar/"
+                        "0000/avatar.png"
+                    ),
+                    "id": 0000,
+                    "name": "Doe, John",
+                    "state": "active",
+                    "username": "johndoe",
+                    "web_url": "https://gitlab.com/johndoe",
+                },
+                "body": "there is a bug",
+                "commands_changes": {},
+                "confidential": False,
+                "created_at": "2022-12-14T19:00:00.000+01:00",
+                "id": 100000,
+                "internal": False,
+                "noteable_id": 20000,
+                "noteable_iid": 15,
+                "noteable_type": "MergeRequest",
+                "project_id": 500,
+                "resolvable": False,
+                "system": True,
+                "type": None,
+                "updated_at": "2022-12-14T20:00:00.000+01:00",
+            }
+        ],
+    }
+]
+
+
+def test_extract_jira() -> None:
+    """Test extracting jira from MR description."""
+    mr = MergeRequest(sample_mr_response, [], sample_mr, "janedoe")
+    assert mr.extract_jira() == "ARTXXX-1000"


### PR DESCRIPTION
Using (?i) is deprecated. Set the re.IGNORECASE flag for regexes instead.

Also added a test for the function where the regex is used.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
